### PR TITLE
Fix vulnerability normalization logic

### DIFF
--- a/vulnerability.m
+++ b/vulnerability.m
@@ -75,14 +75,29 @@ for i = 1:nCols
     if ~isempty(ini)
         nSpells = numel(ini);
         varDef = nan(1, nSpells);
+        varDem = nan(1, nSpells);
         for j = 1:nSpells
             thisDef = def(ini(j):fin(j), i);
-%             thisDem = dem(ini(j):fin(j), i);
+            thisDem = dem(ini(j):fin(j), i);
             varDef(j) = funcAspect(thisDef);
+            varDem(j) = funcAspect(thisDem);
         end
-        v(i) = funcMethod(varDef);
+        switch method
+            case 'mean'
+                v(i) = mean(varDef);
+                vr(i) = mean(varDef./varDem);
+            case 'max'
+                [v(i), idx] = max(varDef);
+                vr(i) = v(i)/varDem(idx);
+            case 'q90'
+                qVal = quantile90(varDef);
+                [~, idx] = min(abs(varDef - qVal));
+                v(i) = varDef(idx);
+                vr(i) = v(i)/varDem(idx);
+        end
     else
         v(i) = 0;
+        vr(i) = 0;
     end
 end
 


### PR DESCRIPTION
## Summary
- implement missing normalized vulnerability calculation

## Testing
- `octave --version` *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_684208e820a4832082a18fb3015b65bb)